### PR TITLE
Setup Dockerfile and scripts for topicctl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,16 @@ RUN cd /go/src/${SRC} && \
     GOOS=$TARGETOS GOARCH=$TARGETARCH make topicctl VERSION=${VERSION}
 
 # copy topicctl & scripts to python image
-FROM python:3.12-alpine
+FROM python:3.12-slim
 
 COPY --from=builder \
     /go/src/github.com/getsentry/topicctl/build/topicctl \
     /bin/topicctl
-COPY --from=builder \
-    /go/src/github.com/getsentry/topicctl/scripts \
-    /bin/scripts
 
-ENTRYPOINT ["/bin/topicctl"]
+COPY scripts/* /bin/
+COPY py/*.py /bin/
+COPY py/requirements.txt /
+
+RUN pip install -r requirements.txt
+
+CMD ["/bin/topicctl"]

--- a/py/parse_and_notify.py
+++ b/py/parse_and_notify.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+import json
+import sys 
+
+def main():
+    print("Parsing input", file=sys.stderr)
+    input_data = sys.stdin.read()
+    parsed = json.loads(input_data)
+    # TODO: Do something
+    
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/run_and_notify
+++ b/scripts/run_and_notify
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eux
+
+topicctl "$@" | parse_and_notify.py


### PR DESCRIPTION
This prepares the scripts to wire up topicctl with the python logic that 
parses the json output and notifies us.

For now there is one simple single file python script so I left it in the
py directory together with the requirements.txt file.
If we start having more scripts (likely) we will build a python project
with tests and a pyproject.toml in the py directory.

I replaced ENTRY_POINT with A CMD entry in the Dockerfile. This allows us
to override the behavior and both run a simple topicctl and a topicctl
with notifications.

`docker run MY_IMAGE run_and_notify.sh apply --json-output ....`

Runs correctly.
 
