### PR TITLE
Integrate infra event notifier

### DIFF
--- a/py/parse_and_notify.py
+++ b/py/parse_and_notify.py
@@ -9,6 +9,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Mapping, Sequence
 
+from infra_event_notifier.backends.jira import IssueType
 from infra_event_notifier.jira_notifier import JiraNotifier
 
 SENTRY_REGION = os.getenv("SENTRY_REGION", "unknown")
@@ -198,9 +199,7 @@ def main():
                 "check topicctl logs for details on changes"
             )
         tags["topicctl_topic"] = topic_content.name
-        notifier.send(
-            title, text, tags, issue_type="Task", update_text_body=True
-        )
+        notifier.send(title, text, IssueType.TASK, tags, update_text_body=True)
         print(f"{title}", file=sys.stderr)
 
 

--- a/py/parse_and_notify.py
+++ b/py/parse_and_notify.py
@@ -165,8 +165,6 @@ def main():
     ), "No Jira user email in JIRA_USER_EMAIL env var"
 
     notifier = JiraNotifier(
-        "",
-        "",
         jira_api_key=api_key,
         jira_project=proj_id,  # Must be the id of the project, not the name
         jira_url=api_url,
@@ -200,12 +198,9 @@ def main():
                 "check topicctl logs for details on changes"
             )
         tags["topicctl_topic"] = topic_content.name
-        notifier.set_title(title)
-        notifier.set_body(text)
-        notifier.set_tags(tags)
-        notifier.set_issue_type("Task")
-        notifier.set_update_text_body(True)
-        notifier.send()
+        notifier.send(
+            title, text, tags, issue_type="Task", update_text_body=True
+        )
         print(f"{title}", file=sys.stderr)
 
 


### PR DESCRIPTION
Integrates the infra event notifier and switches to Jira Task alerts rather than Datadog

(Requires new release of infra-event-notifier before merging can be done)