### PR TITLE
fix: enable running tests locally

### DIFF
--- a/pkg/util/testing.go
+++ b/pkg/util/testing.go
@@ -32,7 +32,7 @@ func TestKafkaAddr() string {
 	// address
 	testKafkaAddr, ok := os.LookupEnv("KAFKA_TOPICS_TEST_KAFKA_ADDR")
 	if !ok {
-		return "169.254.123.123:9092"
+		return "localhost:9092"
 	}
 
 	return testKafkaAddr


### PR DESCRIPTION
Previously to run tests locally you'd have to set `export KAFKA_TOPICS_TEST_KAFKA_ADDR=localhost:9092` (since that's where our docker-compose spins up the kafka images).

This makes that the default behaviour (since the env var is overridden in CI).