### PR TITLE
OPS-7471: emit event on apply error

### DIFF
--- a/cmd/topicctl/subcmd/apply.go
+++ b/cmd/topicctl/subcmd/apply.go
@@ -315,18 +315,16 @@ func applyTopic(
 		}
 		topicChanges, err := cliRunner.ApplyTopic(ctx, applierConfig)
 		if err != nil {
-			// if one of the steps after updateSettings errors when updating a topic,
-			// we can be in a state where some (but not all) changes were applied
-			// some topic creation errors also still create the topic
+			// If one of the steps after updateSettings errors when updating a topic,
+			// we can be in a state where some (but not all) changes were applied.
+			// Some topic creation errors also still create the topic
 			log.Error("Error detected while creating or updating a topic")
-			if checkForChanges(topicChanges) {
-				log.Error("The following changes were still made:")
-				partialChanges, printErr := printJson(topicChanges)
-				if printErr != nil {
-					log.Error("Error printing JSON changes data")
-				} else {
-					log.Errorf("%#v", partialChanges)
-				}
+			log.Error("The following changes were still made:")
+			partialChanges, printErr := printJson(topicChanges)
+			if printErr != nil {
+				log.Error("Error printing JSON changes data")
+			} else {
+				log.Errorf("%#v", partialChanges)
 			}
 			return err
 		}

--- a/cmd/topicctl/subcmd/apply.go
+++ b/cmd/topicctl/subcmd/apply.go
@@ -220,6 +220,7 @@ func printJson(changes apply.NewOrUpdatedChanges) (map[string]interface{}, error
 	if err != nil {
 		return nil, err
 	}
+	// print json to stdout
 	fmt.Printf("%s\n", jsonChanges)
 	// return unmarshalled map
 	changesMap := make(map[string]interface{})

--- a/cmd/topicctl/subcmd/apply.go
+++ b/cmd/topicctl/subcmd/apply.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"reflect"
 	"syscall"
 	"time"
 
@@ -215,58 +214,17 @@ func applyRun(cmd *cobra.Command, args []string) error {
 	return errs
 }
 
-// check if ReplicaAssignments in an UpdateChangesTracker actually changed
-func validateReplicaChanges(changes *apply.UpdateChangesTracker) *apply.UpdateChangesTracker {
-	replicaAssignments := *changes.ReplicaAssignments
-	keepReplicaAssignments := false
-	for _, partition := range replicaAssignments {
-		if !reflect.DeepEqual(partition.CurrentReplicas, partition.UpdatedReplicas) {
-			keepReplicaAssignments = true
-		}
-	}
-	if !keepReplicaAssignments {
-		changes.ReplicaAssignments = nil
-	}
-	return changes
-}
-
-// helper function to check if there are any actual updates on the topic 
-// when returning applyExistingTopic
-func ensureChangesOccurred(updateChanges *apply.UpdateChangesTracker) (*apply.UpdateChangesTracker) {
-	if (updateChanges.NumPartitions == nil &&
-		updateChanges.NewConfigEntries == nil &&
-		updateChanges.UpdatedConfigEntries == nil &&
-		updateChanges.ReplicaAssignments == nil &&
-		len(updateChanges.MissingKeys) == 0 &&
-		updateChanges.Error == false) {
-		return nil
-	}
-	return updateChanges
-}
-
-// if this is an 'update' change, we need to do some preprocessing
-// to ensure we're not printing a payload without any actual diffs
-func validateChanges(changes apply.NewOrUpdatedChanges) (apply.NewOrUpdatedChanges) {
-	_, isUpdateChange := changes.(*apply.UpdateChangesTracker)
-	if isUpdateChange && changes.(*apply.UpdateChangesTracker) != nil {
-		changes = validateReplicaChanges(changes.(*apply.UpdateChangesTracker))
-		changes = ensureChangesOccurred(changes.(*apply.UpdateChangesTracker))
-	}
-	return changes
-}
-
-
 // isStructNotNil returns if a struct implementing NewOrUpdatedChanges is nil
 func isStructNotNil(changes apply.NewOrUpdatedChanges) bool {
-	switch changes.(type) {
+	switch changes := changes.(type) {
 	case *apply.NewChangesTracker:
-		if changes.(*apply.NewChangesTracker) != nil {
+		if changes != nil {
 			return true
 		} else {
 			return false
 		}
 	case *apply.UpdateChangesTracker:
-		if changes.(*apply.UpdateChangesTracker) != nil {
+		if changes != nil {
 			return true
 		} else {
 			return false
@@ -355,7 +313,6 @@ func applyTopic(
 			TopicConfig:                topicConfig,
 		}
 		topicChanges, err := cliRunner.ApplyTopic(ctx, applierConfig)
-		topicChanges = validateChanges(topicChanges)
 		if err != nil {
 			// If one of the steps after updateSettings errors when updating a topic,
 			// we can be in a state where some (but not all) changes were applied.

--- a/cmd/topicctl/subcmd/apply.go
+++ b/cmd/topicctl/subcmd/apply.go
@@ -214,6 +214,19 @@ func applyRun(cmd *cobra.Command, args []string) error {
 	return errs
 }
 
+// prints changes as JSON to stdout
+func printJson(changes apply.NewOrUpdatedChanges) (map[string]interface{}, error) {
+	jsonChanges, err := json.Marshal(changes)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("%s\n", jsonChanges)
+	// return unmarshalled map
+	changesMap := make(map[string]interface{})
+	err = json.Unmarshal(jsonChanges, &changesMap)
+	return changesMap, err
+}
+
 // isStructNotNil returns if a struct implementing NewOrUpdatedChanges is nil
 func isStructNotNil(changes apply.NewOrUpdatedChanges) bool {
 	switch changes := changes.(type) {
@@ -232,19 +245,6 @@ func isStructNotNil(changes apply.NewOrUpdatedChanges) bool {
 	default:
 		return false
 	}
-}
-
-// prints changes as JSON to stdout
-func printJson(changes apply.NewOrUpdatedChanges) (map[string]interface{}, error) {
-	jsonChanges, err := json.Marshal(changes)
-	if err != nil {
-		return nil, err
-	}
-	fmt.Printf("%s\n", jsonChanges)
-	// return unmarshalled map
-	changesMap := make(map[string]interface{})
-	err = json.Unmarshal(jsonChanges, &changesMap)
-	return changesMap, err
 }
 
 func applyTopic(
@@ -328,7 +328,7 @@ func applyTopic(
 			return err
 		}
 
-		// if validateChanges finds there were no changes, topicChanges gets set to nil
+		// if there were no changes, topicChanges can be nil
 		if isStructNotNil(topicChanges) {
 			if _, err := printJson(topicChanges); err != nil {
 				return err

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -409,8 +409,6 @@ func (t *TopicApplier) applyExistingTopic(
 			t.maxBatchSize,
 			changes,
 		); err != nil {
-			changes.Error = true
-			changes.ErrorMessage = err.Error()
 			return changes, err
 		}
 
@@ -418,8 +416,6 @@ func (t *TopicApplier) applyExistingTopic(
 			ctx,
 			-1,
 		); err != nil {
-			changes.Error = true
-			changes.ErrorMessage = err.Error()
 			return changes, err
 		}
 	}

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -111,6 +111,7 @@ func (changes *UpdateChangesTracker) mergeReplicaAssignments(
 	if changes == nil {
 		return
 	}
+
 	for _, diffAssignment := range desiredAssignments {
 		for i, partition := range *changes.ReplicaAssignments {
 			if partition.Partition == diffAssignment.ID {
@@ -351,11 +352,11 @@ func (t *TopicApplier) applyExistingTopic(
 	}
 
 	changes := &UpdateChangesTracker{
-		Action:       ActionEnumUpdate,
-		DryRun:       t.config.DryRun,
-		Topic:        t.topicName,
-		MissingKeys:  make([]string, 0),
-		Error:        false,
+		Action:      ActionEnumUpdate,
+		DryRun:      t.config.DryRun,
+		Topic:       t.topicName,
+		MissingKeys: make([]string, 0),
+		Error:       false,
 	}
 
 	if err := t.updateSettings(ctx, topicInfo, changes); err != nil {

--- a/pkg/apply/apply_test.go
+++ b/pkg/apply/apply_test.go
@@ -71,7 +71,7 @@ func TestApplyBasicUpdates(t *testing.T) {
 			},
 			Action: "create",
 		}
-		assert.Equal(t, changes, expectedNewChanges)
+		assert.Equal(t, expectedNewChanges, changes)
 
 	// Topic exists and is set up correctly
 	topicInfo, err := applier.adminClient.GetTopic(ctx, topicName, true)
@@ -117,7 +117,7 @@ func TestApplyBasicUpdates(t *testing.T) {
 			MissingKeys: []string{},
 		}
 	
-	assert.Equal(t, changes, expectedUpdateChanges)
+	assert.Equal(t, expectedUpdateChanges, changes)
 
 	// Dropped to only 450 because of retention reduction
 	assert.Equal(t, "27000000", topicInfo.Config[admin.RetentionKey])
@@ -332,7 +332,7 @@ func TestApplyPlacementUpdates(t *testing.T) {
 		{
 			Partition:       3,
 			CurrentReplicas: []int{1, 2},
-			UpdatedReplicas: []int{1, 2},
+			UpdatedReplicas: nil,
 		},
 		{
 			Partition:       4,
@@ -345,7 +345,7 @@ func TestApplyPlacementUpdates(t *testing.T) {
 			UpdatedReplicas: []int{3, 4},
 		},
 	}
-	assert.Equal(t, changes.(*UpdateChangesTracker).ReplicaAssignments, expectedReplicaAssignments)
+	assert.Equal(t, expectedReplicaAssignments, changes.(*UpdateChangesTracker).ReplicaAssignments)
 
 	brokers, err := applier.adminClient.GetBrokers(ctx, nil)
 	require.NoError(t, err)

--- a/pkg/apply/format.go
+++ b/pkg/apply/format.go
@@ -153,6 +153,7 @@ func ProcessTopicConfigIntoChanges(topicName string, topicConfig kafka.TopicConf
 		ReplicationFactor: topicConfig.ReplicationFactor,
 		ConfigEntries:     &configEntries,
 		Action:            ActionEnumCreate,
+		Error:             false,
 	}
 }
 

--- a/py/parse_and_notify.py
+++ b/py/parse_and_notify.py
@@ -41,7 +41,7 @@ def make_markdown_table(
             "# ERROR - the following error occurred while processing this topic:\n"  # noqa
             f"{error_message}\n\n"
         )
-        # if there's actual changes, report them as having still occurred
+        # if changes were still made before an error, report them
         if len(content) > 1:
             table = (
                 error_header

--- a/py/parse_and_notify.py
+++ b/py/parse_and_notify.py
@@ -15,7 +15,10 @@ SENTRY_REGION = os.getenv("SENTRY_REGION", "unknown")
 
 
 def make_markdown_table(
-    headers: Sequence[str], content: Sequence[Sequence[str | int | None]]
+    headers: Sequence[str],
+    content: Sequence[Sequence[str | int | None]],
+    error: bool,
+    error_message: str | None,
 ) -> str:
     """
     Creates a markdown table given a sequence of Sequences of cells.
@@ -32,6 +35,13 @@ def make_markdown_table(
     line = "-" * len(headers)
     rows = [make_row(r) for r in content]
     table = f"{make_row(headers)}{make_row(line)}{''.join(rows)}"
+
+    if error:
+        table = (
+            "# ERROR - the following error occurred while processing this topic:\n"  # noqa
+            f"{error_message}\n\n"
+            "# The following changes were still made:\n"
+        ) + table
 
     return f"%%%\n{table}%%%"
 
@@ -50,29 +60,38 @@ class NewTopic(Topic):
     change_set: Sequence[Sequence[str | int | None]]
     dry_run: bool
     error: bool
+    error_message: str | None
     name: str
 
     def render_table(self) -> str:
         return make_markdown_table(
             headers=["Parameter", "Value"],
             content=[["Topic Name", self.name], *self.change_set],
+            error=self.error,
+            error_message=self.error_message,
         )
 
     @classmethod
     def build(cls, raw_content: Mapping[str, Any]) -> NewTopic:
+        change_set = [["Action (create/update)", "create"]]
+        if raw_content["numPartitions"]:
+            change_set.extend(
+                [["Partition Count", raw_content["numPartitions"]]]
+            )
+        if raw_content["replicationFactor"]:
+            change_set.extend(
+                [["Replication Factor", raw_content["replicationFactor"]]]
+            )
+        change_set += [
+            [str(entry["name"]), str(entry["value"])]
+            for entry in raw_content["configEntries"]
+        ]
         return NewTopic(
             name=raw_content["topic"],
             dry_run=raw_content["dryRun"],
-            error=False,
-            change_set=[
-                ["Action (create/update)", "create"],
-                ["Partition Count", raw_content["numPartitions"]],
-                ["Replication Factor", raw_content["replicationFactor"]],
-            ]
-            + [
-                [str(entry["name"]), str(entry["value"])]
-                for entry in raw_content["configEntries"]
-            ],
+            error=raw_content["error"],
+            error_message=raw_content["errorMessage"],
+            change_set=change_set,
         )
 
 
@@ -81,28 +100,35 @@ class UpdatedTopic(Topic):
     change_set: Sequence[Sequence[str | int | None]]
     dry_run: bool
     error: bool
+    error_message: str | None
     name: str
 
     def render_table(self) -> str:
         return make_markdown_table(
             headers=["Parameter", "Old Value", "New Value"],
             content=self.change_set,
+            error=self.error,
+            error_message=self.error_message,
         )
 
     @classmethod
     def build(cls, raw_content: Mapping[str, Any]) -> UpdatedTopic:
-        change_set = [
-            ["Action (create/update)", "update", ""],
-            [
-                "Partition Count",
-                raw_content["numPartitions"]["current"]
-                if raw_content["numPartitions"]
-                else None,
-                raw_content["numPartitions"]["updated"]
-                if raw_content["numPartitions"]
-                else None,
-            ],
-        ]
+        change_set = [["Action (create/update)", "update", ""]]
+
+        if (
+            raw_content["numPartitions"]
+            and raw_content["numPartitions"]["current"]
+            and raw_content["numPartitions"]["updated"]
+        ):
+            change_set.extend(
+                [
+                    [
+                        "Partition Count",
+                        raw_content["numPartitions"]["current"],
+                        raw_content["numPartitions"]["updated"],
+                    ]
+                ]
+            )
 
         if raw_content["newConfigEntries"]:
             change_set.extend(
@@ -148,6 +174,7 @@ class UpdatedTopic(Topic):
             name=raw_content["topic"],
             dry_run=raw_content["dryRun"],
             error=raw_content["error"],
+            error_message=raw_content["errorMessage"],
             change_set=change_set,
         )
 

--- a/py/parse_and_notify.py
+++ b/py/parse_and_notify.py
@@ -37,11 +37,19 @@ def make_markdown_table(
     table = f"{make_row(headers)}{make_row(line)}{''.join(rows)}"
 
     if error:
-        table = (
+        error_header = (
             "# ERROR - the following error occurred while processing this topic:\n"  # noqa
             f"{error_message}\n\n"
-            "# The following changes were still made:\n"
-        ) + table
+        )
+        # if there's actual changes, report them as having still occurred
+        if len(content) > 1:
+            table = (
+                error_header
+                + "# The following changes were still made:\n\n"
+                + table
+            )
+        else:
+            table = error_header + "# No changes were made."
 
     return f"%%%\n{table}%%%"
 
@@ -86,6 +94,9 @@ class NewTopic(Topic):
             [str(entry["name"]), str(entry["value"])]
             for entry in raw_content["configEntries"]
         ]
+        # if nothing changed, report no changes
+        if len(change_set) == 1:
+            change_set = []
         return NewTopic(
             name=raw_content["topic"],
             dry_run=raw_content["dryRun"],
@@ -169,6 +180,8 @@ class UpdatedTopic(Topic):
                     for p in assignments
                 ]
             )
+        if len(change_set) == 1:
+            change_set = []
 
         return UpdatedTopic(
             name=raw_content["topic"],


### PR DESCRIPTION
This PR:
- makes it so that an error during apply during topic creation & updating always reports an event to datadog
- slightly refactors how `ReplicaAssignments` are tracked, as well as how topicctl determines if any actual changes occurred during topic update

Examples:
- [error event during topic creation](https://app.datadoghq.com/event/explorer?query=source%3Atopicctl&cols=&event=AgAAAZEzJ7kY7on9hAAAAAAAAAAYAAAAAEFaRXpKN2tZQUFDakZWZ2c2Ti1Ka2x1YQAAACQAAAAAMDE5MTMzMmQtZGI2OC00YmE4LTg3YzEtMjRiNzMyNjA2YzY4&messageDisplay=expanded-lg&options=&refresh_mode=sliding&sort=DESC&view=spans&from_ts=1723137272000&to_ts=1723140872000&live=true)
- [error event after changes are made during update](https://app.datadoghq.com/event/explorer?query=source%3Atopicctl&cols=&event=AgAAAZEzIzyoIiT8_gAAAAAAAAAYAAAAAEFaRXpJMENRQUFEazlxUjdPXzNweUthTQAAACQAAAAAMDE5MTMzMjYtOGM1MC00ZjZiLWFlNTYtYTVlNDExZGIzNWUy&messageDisplay=expanded-lg&options=&refresh_mode=sliding&sort=DESC&view=spans&from_ts=1723137272000&to_ts=1723140872000&live=true)
- [error event without any changes made during update](https://app.datadoghq.com/event/explorer?query=source%3Atopicctl&cols=&event=AgAAAZEzIMPYiAchNwAAAAAAAAAYAAAAAEFaRXpJTVBZQUFER1kyeHBCaHdqcVNIXwAAACQAAAAAMDE5MTMzMjYtOGM1MC00ZjZiLWFlNTYtYTVlNDExZGIzNWUy&messageDisplay=expanded-lg&options=&refresh_mode=sliding&sort=DESC&view=spans&from_ts=1723137329916&to_ts=1723140929916&live=true)