### PR TITLE
Fix source category tag

### DIFF
--- a/py/parse_and_notify.py
+++ b/py/parse_and_notify.py
@@ -262,7 +262,7 @@ def main():
         tags = {
             "source": "topicctl",
             "source_tool": "topicctl",
-            "source_category": "infra_tools",
+            "source_category": "infra-tools",
             "sentry_region": SENTRY_REGION,
         }
 


### PR DESCRIPTION
Source category tag was misspelled thus making the event disappear
from the dashboard
