### PR TITLE
INC-855: add extra logging for leader rebalance

### DIFF
--- a/pkg/admin/types.go
+++ b/pkg/admin/types.go
@@ -692,11 +692,13 @@ func (t TopicInfo) WrongLeaderPartitions(subset []int) []PartitionInfo {
 		if _, ok := subsetMap[partition.ID]; len(subset) > 0 && !ok {
 			continue
 		}
+		log.Infof("partition leader = %d, partition replicas = %#v", partition.Leader, partition.Replicas)
 
 		if partition.Leader != partition.Replicas[0] {
 			wrongLeaders = append(wrongLeaders, partition)
 		}
 	}
+	log.Infof("wrongLeaders = %#v", wrongLeaders)
 
 	return wrongLeaders
 }


### PR DESCRIPTION
This adds extra logging for the step that detects if a partition has wrong leaders assigned.

Multiple `transactions` topics in the US region have no leaders on broker 2 but aren't being rebalanced by topicctl:
```
scheduled-subscriptions-transactions
     21 transactions-kafka-0.c.internal-sentry.internal:9092
     11 transactions-kafka-1.c.internal-sentry.internal:9092
snuba-transactions-commit-log
      1 transactions-kafka-1.c.internal-sentry.internal:9092
transactions-1
     43 transactions-kafka-0.c.internal-sentry.internal:9092
     21 transactions-kafka-1.c.internal-sentry.internal:9092
```

The code that detects this runs every `apply` even without the `--rebalance` flag