### PR TITLE
chore: bump minumum python to 3.10

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -5,11 +5,11 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "topicctl_integration"
 version = "0.0.1"
-requires-python = ">= 3.8"
+requires-python = ">= 3.10"
 
 [tool.black]
 line-length = 79
-target-version = ['py38']
+target-version = ['py310', 'py311', 'py312']
 skip-magic-trailing-comma = true
 
 [tool.isort]


### PR DESCRIPTION
This is required due to the bumping of the minimum version in `infra-event-notifier`: https://github.com/getsentry/infra-event-notifier/pull/11

This should be a no-op as we use 3.12 in the image:
```Dockerfile
FROM python:3.12-slim-bookworm
```