### PR TITLE
feat(rebalance): error if a topic migration is ongoing

### DIFF
--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -510,10 +510,11 @@ func (t *TopicApplier) checkExistingState(
 			}
 		}
 	} else {
-		log.Warnf(
+		log.Errorf(
 			"One or more replicas are not in-sync; there may be an ongoing migration:\n%s",
 			admin.FormatTopicPartitions(outOfSync, t.brokers),
 		)
+		return errors.New("One or more replicas are not in-sync; there may be an ongoing migration")
 	}
 
 	return nil

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -514,7 +514,7 @@ func (t *TopicApplier) checkExistingState(
 			"One or more replicas are not in-sync; there may be an ongoing migration:\n%s",
 			admin.FormatTopicPartitions(outOfSync, t.brokers),
 		)
-		return errors.New("One or more replicas are not in-sync; there may be an ongoing migration")
+		return errors.New("One or more replicas are not in-sync; we are likely horizontally scaling the cluster that this topic is on")
 	}
 
 	return nil


### PR DESCRIPTION
Currently, if:
- 3 new brokers are added to a cluster
- a `topicctl apply` job runs to rebalance partitions across the new brokers (which takes >1 hour)
- another `topicctl apply` job runs while the 1st job is still rebalancing

The 2nd job outputs this in the logs, then errors:
```
time="2025-02-18 19:45:14" level=warning msg="One or more replicas are not in-sync; there may be an ongoing migration:
-----+--------+-------------+---------+----------+----------------------------------------------------------+--------------
  ID | LEADER |  REPLICAS   |   ISR   | DISTINCT |                          RACKS                           |   STATUS
     |        |             |         |  RACKS   |                                                          |
-----+--------+-------------+---------+----------+----------------------------------------------------------+--------------
   1 |      1 | [1 6 8 0 2] | [1 0 2] |        3 | [us-east1-c us-east1-b us-east1-d us-east1-b us-east1-d] | Out-of-sync
-----+--------+-------------+---------+----------+----------------------------------------------------------+--------------"
time="2025-02-18 19:45:14" level=info msg="Checking topic config settings..."
time="2025-02-18 19:45:14" level=info msg="Found 2 key(s) set in cluster but missing from config to be deleted:
------------------------------------------+----------------
                    KEY                   | CLUSTER VALUE
------------------------------------------+----------------
  leader.replication.throttled.replicas   | 1:0,1:1,1:2
  follower.replication.throttled.replicas | 1:6,1:8
------------------------------------------+----------------"
```
The `leader.replication.throttled.replicas` and `follower.replication.throttled.replicas` settings mentioned above are throttles automatically created by the 1st job doing the rebalancing on the partition. Currently, the 2nd job will delete these settings before erroring out while the 1st job is still replicating (as we run topicctl with the `--destructive` flag).

This PR changes this behaviour so that topicctl errors out immediately if it detects a topic migration is ongoing.