### PR TITLE
fix: don't error on racks not being filled out

### DIFF
--- a/pkg/apply/assigners/evaluate.go
+++ b/pkg/apply/assigners/evaluate.go
@@ -61,12 +61,15 @@ func EvaluateAssignments(
 	case config.PlacementStrategyCrossRack:
 		brokerRacks := admin.BrokerRacks(brokers)
 		for _, assignment := range assignments {
+			// If a topicctl rebalance gets stopped while running, we can be in a state where
+			// multiple replicas are on the same rack. This should be fixed on a re-run with
+			// cross-rack assignment.
 			if len(assignment.Replicas) != len(assignment.DistinctRacks(brokerRacks)) {
-				log.Errorf(
+				log.Warnf(
 					"Expected replicas to equal number of racks, but got %d replicas and %d racks for assignment %v",
 					len(assignment.Replicas), len(assignment.DistinctRacks(brokerRacks)), assignment,
 				)
-				return false, nil
+				return true, nil
 			}
 		}
 		return true, nil


### PR DESCRIPTION
If topicctl stops while running while rebalancing, we can get into a state where we have 2 partition replicas on one rack, 1 partition on another rack, and no partitions on the third rack. Topicctl erroring out when this happens prevents us from fixing this issue (via another topicctl rebalance), so this changes topicctl to just log a warning and continue with rebalancing.