### PR TITLE
Manage non topic specific topicctl errors

### DIFF
--- a/py/parse_and_notify.py
+++ b/py/parse_and_notify.py
@@ -251,7 +251,21 @@ def main():
     )
 
     for line in sys.stdin:
-        topic = json.loads(line)
+        try:
+            topic = json.loads(line)
+        except json.JSONDecodeError:
+            title = f"Topicctl failed to apply in region {SENTRY_REGION}"
+            slack_notifier.send(
+                title=title, body="Topicctl produced invalid JSON"
+            )
+            raise
+
+        if "error" in topic:
+            title = f"Topicctl failed to apply in region {SENTRY_REGION}"
+            slack_notifier.send(title=title, body=topic["error"])
+            print(f"Error: {topic['error']}", file=sys.stderr)
+            exit(-1)
+
         action = topic["action"]
         topic_content = (
             NewTopic.build(topic)

--- a/py/parse_and_notify.py
+++ b/py/parse_and_notify.py
@@ -253,10 +253,10 @@ def main():
     for line in sys.stdin:
         try:
             topic = json.loads(line)
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as e:
             title = f"Topicctl failed to apply in region {SENTRY_REGION}"
             slack_notifier.send(
-                title=title, body="Topicctl produced invalid JSON"
+                title=title, body=f"Topicctl produced invalid JSON: {e}"
             )
             raise
 


### PR DESCRIPTION
If we have an error in applying one specific topic we serialize the error
in the json output and the parser script manages it properly.

Though, if the whole process fails because the config is invalid,
we do not produce any json and parse_and_notify fails without sending
notifications.

THis prodices a valid json and tries to send a notification when json is invalid
