### PR TITLE
fix: switch bitnami to bitnamilegacy images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,14 +53,14 @@ jobs:
 
     services:
       zookeeper:
-        image: bitnami/zookeeper:latest
+        image: bitnamilegacy/zookeeper:latest
         ports:
           - "2181:2181"
         env:
           ALLOW_ANONYMOUS_LOGIN: yes
 
       kafka1:
-        image: bitnami/kafka:2.7.0
+        image: bitnamilegacy/kafka:2.7.0
         ports:
           - "9092:9092"
         env:
@@ -74,7 +74,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
       kafka2:
-        image: bitnami/kafka:2.7.0
+        image: bitnamilegacy/kafka:2.7.0
         ports:
           - "9093:9092"
         env:
@@ -88,7 +88,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
       kafka3:
-        image: bitnami/kafka:2.7.0
+        image: bitnamilegacy/kafka:2.7.0
         ports:
           - "9094:9092"
         env:
@@ -102,7 +102,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
       kafka4:
-        image: bitnami/kafka:2.7.0
+        image: bitnamilegacy/kafka:2.7.0
         ports:
           - "9095:9092"
         env:
@@ -116,7 +116,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
       kafka5:
-        image: bitnami/kafka:2.7.0
+        image: bitnamilegacy/kafka:2.7.0
         ports:
           - "9096:9092"
         env:
@@ -130,7 +130,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
       kafka6:
-        image: bitnami/kafka:2.7.0
+        image: bitnamilegacy/kafka:2.7.0
         ports:
           - "9097:9092"
         env:
@@ -169,14 +169,14 @@ jobs:
 
     services:
       zookeeper:
-        image: bitnami/zookeeper:latest
+        image: bitnamilegacy/zookeeper:latest
         ports:
           - "2181:2181"
         env:
           ALLOW_ANONYMOUS_LOGIN: yes
 
       kafka1:
-        image: bitnami/kafka:3.6.0
+        image: bitnamilegacy/kafka:3.6.0
         ports:
           - "9092:9092"
         env:
@@ -190,7 +190,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
       kafka2:
-        image: bitnami/kafka:3.6.0
+        image: bitnamilegacy/kafka:3.6.0
         ports:
           - "9093:9092"
         env:
@@ -204,7 +204,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
       kafka3:
-        image: bitnami/kafka:3.6.0
+        image: bitnamilegacy/kafka:3.6.0
         ports:
           - "9094:9092"
         env:
@@ -218,7 +218,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
       kafka4:
-        image: bitnami/kafka:3.6.0
+        image: bitnamilegacy/kafka:3.6.0
         ports:
           - "9095:9092"
         env:
@@ -232,7 +232,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
       kafka5:
-        image: bitnami/kafka:3.6.0
+        image: bitnamilegacy/kafka:3.6.0
         ports:
           - "9096:9092"
         env:
@@ -246,7 +246,7 @@ jobs:
           KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: true
 
       kafka6:
-        image: bitnami/kafka:3.6.0
+        image: bitnamilegacy/kafka:3.6.0
         ports:
           - "9097:9092"
         env:

--- a/README.md
+++ b/README.md
@@ -644,7 +644,7 @@ make test
 
 You can change the Kafka version of the local cluster by setting the
 `KAFKA_IMAGE_TAG` environment variable when running `docker-compose up -d`. See the
-[`bitnami/kafka` dockerhub page](https://hub.docker.com/r/bitnami/kafka/tags) for more
+[`bitnami/kafka` dockerhub page](https://hub.docker.com/r/bitnamilegacy/kafka/tags) for more
 details on the available versions.
 
 #### Run against local cluster

--- a/docker-compose-auth.yml
+++ b/docker-compose-auth.yml
@@ -18,7 +18,7 @@ services:
   zookeeper:
     container_name: zookeeper
     hostname: zookeeper
-    image: bitnami/zookeeper:latest
+    image: bitnamilegacy/zookeeper:latest
     ports:
       - "2181:2181"
     environment:
@@ -27,7 +27,7 @@ services:
   kafka:
     container_name: kafka
     hostname: kafka
-    image: bitnami/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
+    image: bitnamilegacy/kafka:${KAFKA_IMAGE_TAG:-2.7.0}
     depends_on:
       - zookeeper
     restart: on-failure:3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   zookeeper:
     container_name: zookeeper
     hostname: zookeeper
-    image: bitnami/zookeeper:latest
+    image: bitnamilegacy/zookeeper:latest
     ports:
       - "2181:2181"
     environment:


### PR DESCRIPTION
Bitnami moved all their images to `bitnamilegacy` and stopped supporting them.
We should eventually swap over to use the main images for [zookeeper](https://hub.docker.com/_/zookeeper) and [kafka](https://hub.docker.com/r/confluentinc/cp-kafka/).